### PR TITLE
5장 05-13 예제 수정

### DIFF
--- a/ch05/05-13.html
+++ b/ch05/05-13.html
@@ -33,7 +33,7 @@
             :key="item"
           >
             {{item}}
-            <span v-if="index === currentIndex" className="float-right badge badge-secondary">
+            <span v-if="index === currentIndex" class="float-end badge bg-secondary">
               <i class="fa fa-arrow-left" aria-hidden="true"></i>
             </span>
           </li>


### PR DESCRIPTION
Bootstrap 5 스타일 클래스 이름으로 수정

---

안녕하세요. 

예제 05-13에서 다음 내용을 수정했습니다.
* `className` -> `class`
  * JSX 파일이  아니고 일반 HTML 파일이여서 속성명을 class로 변경
* `float-right` -> `float-end`,  
   `badge-secondary` -> `bg-secondary`
  * Bootstrap 5가 되면서 스타일 클래스 이름이 바뀐 부분에 대해 맞춰서 수정


139쪽에 스크린샷 화면과는 좀 달라지지만...
![image](https://github.com/user-attachments/assets/29c80789-c969-40c1-b9f4-d681debee82a)

회색 배경의 뱃지 화살표가 오른쪽에 배치되는 화면이됩니다.


책 잘 읽고 있습니다. 감사합니다. 👍